### PR TITLE
RK-14638 - Fix!: variable typo and examples output

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ demo.PROVIDE_DOMAIN - flask demo application for debuging when DNS provided.
 | <a name="input_internal_controller_alb"></a> [internal\_controller\_alb](#input\_internal\_controller\_alb) | If domain provided, switching in on will make controller be reachable internaly only | `bool` | `false` | no |
 | <a name="input_region"></a> [region](#input\_region) | AWS region, using providers region as default | `string` | `""` | no |
 | <a name="input_rookout_token"></a> [rookout\_token](#input\_rookout\_token) | Rookout token | `string` | n/a | yes |
-| <a name="input_vpc_avilability_zones"></a> [vpc\_avilability\_zones](#input\_vpc\_avilability\_zones) | n/a | `list(string)` | <pre>[<br>  "eu-west-1a",<br>  "eu-west-1b"<br>]</pre> | no |
+| <a name="input_vpc_availability_zones"></a> [vpc\_availability\_zones](#input\_vpc\_availability\_zones) | n/a | `list(string)` | <pre>[<br>  "eu-west-1a",<br>  "eu-west-1b"<br>]</pre> | no |
 | <a name="input_vpc_cidr"></a> [vpc\_cidr](#input\_vpc\_cidr) | n/a | `string` | `"172.30.1.0/25"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | VPC id should be passed only if create\_vpc = false | `string` | `""` | no |
 | <a name="input_vpc_private_subnets"></a> [vpc\_private\_subnets](#input\_vpc\_private\_subnets) | n/a | `list(string)` | <pre>[<br>  "172.30.1.0/27",<br>  "172.30.1.32/27"<br>]</pre> | no |

--- a/example/rookout_certificate_datastore.tf
+++ b/example/rookout_certificate_datastore.tf
@@ -3,6 +3,8 @@
 # controller will be deployed with internal load balancer. 
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
+        # version = x.y.z
+    
     datastore_acm_certificate_arn = "PRE_IMPORTED_ACM_CERTIFICATE_ARN"
     rookout_token = "YOUR_TOKEN"
 }

--- a/example/rookout_certificate_datastore.tf
+++ b/example/rookout_certificate_datastore.tf
@@ -3,8 +3,10 @@
 # controller will be deployed with internal load balancer. 
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
-    # version = x.y.z
-    
     datastore_acm_certificate_arn = "PRE_IMPORTED_ACM_CERTIFICATE_ARN"
     rookout_token = "YOUR_TOKEN"
+}
+
+output "rookout" {
+    value = module.rookout
 }

--- a/example/rookout_certificate_datastore_controller.tf
+++ b/example/rookout_certificate_datastore_controller.tf
@@ -3,6 +3,8 @@
 # in this option controller will be internet facing using same mechanism.
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
+    # version = x.y.z
+    
     datastore_acm_certificate_arn = "PRE_IMPORTED_ACM_CERTIFICATE_ARN"
     controller_acm_certificate_arn = "PRE_IMPORTED_ACM_CERTIFICATE_ARN"
     rookout_token = "YOUR_TOKEN"

--- a/example/rookout_certificate_datastore_controller.tf
+++ b/example/rookout_certificate_datastore_controller.tf
@@ -1,11 +1,13 @@
-# This deployment will use pre-imported arn of certificate in ACM ( for that needed Body, private key and chain )
+# This deployment will use pre-imported arn of certificate in ACM (for that needed Body, private key and chain)
 # that will be used by datastore, therefore CNAME record of certificate's domain should be recored at your's DNS provider.
 # in this option controller will be internet facing using same mechanism.
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
-    # version = x.y.z
-    
     datastore_acm_certificate_arn = "PRE_IMPORTED_ACM_CERTIFICATE_ARN"
     controller_acm_certificate_arn = "PRE_IMPORTED_ACM_CERTIFICATE_ARN"
     rookout_token = "YOUR_TOKEN"
+}
+
+output "rookout" {
+    value = module.rookout
 }

--- a/example/rookout_default.tf
+++ b/example/rookout_default.tf
@@ -1,5 +1,7 @@
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"    
+    # version = x.y.z
+    
     domain_name = "YOUR_DOMAIN"
     rookout_token = "YOUR_TOKEN"
 }

--- a/example/rookout_default.tf
+++ b/example/rookout_default.tf
@@ -1,7 +1,9 @@
 module "rookout" {
-    source  = "Rookout/rookout-deployment/aws"
-    # version = x.y.z
-    
+    source  = "Rookout/rookout-deployment/aws"    
     domain_name = "YOUR_DOMAIN"
     rookout_token = "YOUR_TOKEN"
+}
+
+output "rookout" {
+    value = module.rookout
 }

--- a/example/rookout_domain_internal_ctrl copy.tf
+++ b/example/rookout_domain_internal_ctrl copy.tf
@@ -1,9 +1,11 @@
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
-    # version = x.y.z
-    
     domain_name = "YOUR_DOMAIN"
     rookout_token = "YOUR_TOKEN"
 
     internal_controller_alb = true
+}
+
+output "rookout" {
+    value = module.rookout
 }

--- a/example/rookout_domain_internal_ctrl copy.tf
+++ b/example/rookout_domain_internal_ctrl copy.tf
@@ -1,5 +1,7 @@
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
+    # version = x.y.z
+    
     domain_name = "YOUR_DOMAIN"
     rookout_token = "YOUR_TOKEN"
 

--- a/example/rookout_domain_internal_ctrl.tf
+++ b/example/rookout_domain_internal_ctrl.tf
@@ -1,8 +1,10 @@
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
-    # version = x.y.z
-    
     domain_name = "YOUR_ROUTE53_DOMAIN"
     rookout_token = "YOUR_TOKEN"
     internal_controller_alb = true
+}
+
+output "rookout" {
+    value = module.rookout
 }

--- a/example/rookout_domain_internal_ctrl.tf
+++ b/example/rookout_domain_internal_ctrl.tf
@@ -1,5 +1,7 @@
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
+    # version = x.y.z
+    
     domain_name = "YOUR_ROUTE53_DOMAIN"
     rookout_token = "YOUR_TOKEN"
     internal_controller_alb = true

--- a/example/rookout_existing_vpc.tf
+++ b/example/rookout_existing_vpc.tf
@@ -1,7 +1,5 @@
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
-    # version = x.y.z
-    
     environment = "rookout"
     region = "YOUR REGION" # will use provider region if not provided
     domain_name = "YOUR_DOMAIN"
@@ -17,4 +15,8 @@ module "rookout" {
     vpc_id = "<your vpc id>"
     vpc_public_subnets = ["<first_sub_domain>", "<second_sub_domain>"]
     vpc_private_subnets = ["<first_sub_domain>", "<second_sub_domain>"]
+}
+
+output "rookout" {
+    value = module.rookout
 }

--- a/example/rookout_existing_vpc.tf
+++ b/example/rookout_existing_vpc.tf
@@ -1,5 +1,7 @@
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
+    # version = x.y.z
+    
     environment = "rookout"
     region = "YOUR REGION" # will use provider region if not provided
     domain_name = "YOUR_DOMAIN"

--- a/example/rookout_existing_vpc_and_cluster.tf
+++ b/example/rookout_existing_vpc_and_cluster.tf
@@ -1,5 +1,7 @@
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
+    # version = x.y.z
+    
     environment = "rookout"
     region = "YOUR REGION" # will use provider region if not provided
     domain_name = "YOUR_DOMAIN.com"

--- a/example/rookout_existing_vpc_and_cluster.tf
+++ b/example/rookout_existing_vpc_and_cluster.tf
@@ -1,7 +1,5 @@
 module "rookout" {
     source  = "Rookout/rookout-deployment/aws"
-    # version = x.y.z
-    
     environment = "rookout"
     region = "YOUR REGION" # will use provider region if not provided
     domain_name = "YOUR_DOMAIN.com"
@@ -18,4 +16,8 @@ module "rookout" {
     vpc_id = "<your vpc id>"
     vpc_public_subnets = ["<first_sub_domain>", "<second_sub_domain>"]
     vpc_private_subnets = ["<first_sub_domain>", "<second_sub_domain>"]
+}
+
+output "rookout" {
+    value = module.rookout
 }

--- a/variables.tf
+++ b/variables.tf
@@ -91,7 +91,7 @@ variable "vpc_cidr" {
   default = "172.30.1.0/25"
 }
 
-variable "vpc_avilability_zones" {
+variable "vpc_availability_zones" {
   type    = list(string)
   default = ["eu-west-1a", "eu-west-1b"]
 }

--- a/vpc.tf
+++ b/vpc.tf
@@ -6,7 +6,7 @@ module "vpc" {
   name = "${var.environment}-rookout-vpc"
   cidr = var.vpc_cidr
 
-  azs             = var.vpc_avilability_zones
+  azs             = var.vpc_availability_zones
   private_subnets = var.vpc_private_subnets
   public_subnets  = var.vpc_public_subnets
 


### PR DESCRIPTION
Fixed a typo in one of the variables, and
added output to all of the examples.